### PR TITLE
Create a margin property

### DIFF
--- a/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
+++ b/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
@@ -64,4 +64,18 @@ class MarginCommandTest {
         assertEquals(valueInPx, layoutParams.rightMargin)
         assertEquals(valueInPx, layoutParams.bottomMargin)
     }
+
+    @Test
+    fun whenMarginIsSetPassingInvalidValue_shouldThrowException() {
+        val dynamicProperty = DynamicProperty(MARGIN, "dimen", "WRONG")
+        val parent = LinearLayout(context)
+        val view = TextView(context)
+        parent.addView(view)
+
+        exceptionRule.expect(IllegalArgumentException::class.java)
+        exceptionRule.expectMessage("The value WRONG is not a valid margin" +
+            " value, it need to be a number")
+
+        marginCommand.apply(view, dynamicProperty)
+    }
 }

--- a/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
+++ b/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
@@ -74,7 +74,7 @@ class MarginCommandTest {
 
         exceptionRule.expect(IllegalArgumentException::class.java)
         exceptionRule.expectMessage("The value WRONG is not a valid margin" +
-            " value, it need to be a number")
+            " value, it needs to be a number")
 
         marginCommand.apply(view, dynamicProperty)
     }
@@ -87,7 +87,8 @@ class MarginCommandTest {
         parent.addView(view)
 
         exceptionRule.expect(IllegalArgumentException::class.java)
-        exceptionRule.expectMessage("The margin value must be a array of 4 items or one number")
+        exceptionRule.expectMessage("The margin value must be an array of 4 items or " +
+            "a single number representing the values of all corners")
 
         marginCommand.apply(view, dynamicProperty)
     }

--- a/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
+++ b/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
@@ -78,4 +78,17 @@ class MarginCommandTest {
 
         marginCommand.apply(view, dynamicProperty)
     }
+
+    @Test
+    fun whenSetInvalidArraySizeOfMargin_shouldThrowException() {
+        val dynamicProperty = DynamicProperty(MARGIN, "dimen", "16, 16, 16")
+        val parent = LinearLayout(context)
+        val view = TextView(context)
+        parent.addView(view)
+
+        exceptionRule.expect(IllegalArgumentException::class.java)
+        exceptionRule.expectMessage("The margin value must be a array of 4 items or one number")
+
+        marginCommand.apply(view, dynamicProperty)
+    }
 }

--- a/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
+++ b/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
@@ -4,7 +4,6 @@ import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.widget.LinearLayout
 import android.widget.TextView
-import br.com.concrete.yosef.api.property.elementgroup.GravityCommand
 import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.entity.DynamicProperty

--- a/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
+++ b/core/src/androidTest/kotlin/br/com/concrete/yosef/property/spacing/MarginCommandTest.kt
@@ -1,0 +1,68 @@
+package br.com.concrete.yosef.property.spacing
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import android.widget.LinearLayout
+import android.widget.TextView
+import br.com.concrete.yosef.api.property.elementgroup.GravityCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
+import br.com.concrete.yosef.entity.DynamicProperty
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import kotlin.math.roundToInt
+
+@RunWith(AndroidJUnit4::class)
+class MarginCommandTest {
+
+    @Rule
+    @JvmField
+    val exceptionRule: ExpectedException = ExpectedException.none()
+
+    private val context = InstrumentationRegistry.getTargetContext()!!
+
+    private lateinit var marginCommand: MarginPropertyCommand
+
+    @Before
+    fun setUp() {
+        marginCommand = MarginPropertyCommand()
+    }
+
+    @Test
+    fun whenMarginIsSetToView_shouldSetTheCorrectValues() {
+        val dynamicProperty = DynamicProperty(MARGIN, "dimen", "16, 0, 16, 0")
+        val parent = LinearLayout(context)
+        val view = TextView(context)
+        parent.addView(view)
+        val valueInPx: Int = (16 * context.resources.displayMetrics.density).roundToInt()
+
+        marginCommand.apply(view, dynamicProperty)
+
+        val layoutParams = view.layoutParams as LinearLayout.LayoutParams
+        assertEquals(valueInPx, layoutParams.leftMargin)
+        assertEquals(0, layoutParams.topMargin)
+        assertEquals(valueInPx, layoutParams.rightMargin)
+        assertEquals(0, layoutParams.bottomMargin)
+    }
+
+    @Test
+    fun whenMarginIsSetPassingOneValue_shouldSetTheSameValueToAllMargins() {
+        val dynamicProperty = DynamicProperty(MARGIN, "dimen", "16")
+        val parent = LinearLayout(context)
+        val view = TextView(context)
+        parent.addView(view)
+        val valueInPx: Int = (16 * context.resources.displayMetrics.density).roundToInt()
+
+        marginCommand.apply(view, dynamicProperty)
+
+        val layoutParams = view.layoutParams as LinearLayout.LayoutParams
+        assertEquals(valueInPx, layoutParams.leftMargin)
+        assertEquals(valueInPx, layoutParams.topMargin)
+        assertEquals(valueInPx, layoutParams.rightMargin)
+        assertEquals(valueInPx, layoutParams.bottomMargin)
+    }
+}

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/DynamicViewCreator.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/DynamicViewCreator.kt
@@ -88,9 +88,9 @@ class DynamicViewCreator(
         val view = component.createView(topLevelViewGroup.context)
 
         childComponent.children?.forEach { addChildrenRecursively(view as ViewGroup, it) }
-        component.applyProperties(view, childComponent.dynamicProperties, listener)
 
         topLevelViewGroup.addView(view)
+        component.applyProperties(view, childComponent.dynamicProperties, listener)
     }
 
     /**

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/ButtonComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/ButtonComponent.kt
@@ -11,6 +11,8 @@ import br.com.concrete.yosef.api.property.color.BackgroundColorCommand
 import br.com.concrete.yosef.api.property.color.BackgroundColorCommand.Companion.BACKGROUND_COLOR
 import br.com.concrete.yosef.api.property.id.IdCommand
 import br.com.concrete.yosef.api.property.id.IdCommand.Companion.ID
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.api.property.text.TextColorCommand
@@ -38,6 +40,7 @@ class ButtonComponent : Component {
         TEXT_COLOR to TextColorCommand(),
         BACKGROUND_COLOR to BackgroundColorCommand(),
         PADDING to PaddingPropertyCommand(),
+        MARGIN to MarginPropertyCommand(),
         ID to IdCommand()
     )
 

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/ElementGroupComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/ElementGroupComponent.kt
@@ -12,6 +12,8 @@ import br.com.concrete.yosef.api.property.elementgroup.OrientationCommand
 import br.com.concrete.yosef.api.property.elementgroup.OrientationCommand.Companion.ORIENTATION
 import br.com.concrete.yosef.api.property.id.IdCommand
 import br.com.concrete.yosef.api.property.id.IdCommand.Companion.ID
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.entity.DynamicProperty
@@ -32,6 +34,7 @@ class ElementGroupComponent : Component {
     private val components: Map<String, DynamicPropertyCommand> = mapOf(
         ORIENTATION to OrientationCommand(),
         PADDING to PaddingPropertyCommand(),
+        MARGIN to MarginPropertyCommand(),
         ID to IdCommand()
     )
 

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/FrameComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/FrameComponent.kt
@@ -9,6 +9,10 @@ import br.com.concrete.yosef.OnActionListener
 import br.com.concrete.yosef.api.property.DynamicPropertyCommand
 import br.com.concrete.yosef.api.property.id.IdCommand
 import br.com.concrete.yosef.api.property.id.IdCommand.Companion.ID
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
+import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.entity.DynamicProperty
 
 /**
@@ -25,13 +29,15 @@ class FrameComponent : Component {
     }
 
     private val components: Map<String, DynamicPropertyCommand> = mapOf(
-            ID to IdCommand()
+        MARGIN to MarginPropertyCommand(),
+        PADDING to PaddingPropertyCommand(),
+        ID to IdCommand()
     )
 
     override fun applyProperties(
-            view: View,
-            dynamicProperties: List<DynamicProperty>,
-            actionListener: OnActionListener?
+        view: View,
+        dynamicProperties: List<DynamicProperty>,
+        actionListener: OnActionListener?
     ) {
         dynamicProperties.forEach {
             components[it.name]?.apply(view, it)
@@ -41,7 +47,7 @@ class FrameComponent : Component {
     override fun createView(context: Context): View {
         return FrameLayout(context).apply {
             layoutParams = LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         }
     }
 }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/RadioButtonComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/RadioButtonComponent.kt
@@ -13,6 +13,8 @@ import br.com.concrete.yosef.api.property.color.TintColorCommand
 import br.com.concrete.yosef.api.property.color.TintColorCommand.Companion.TINT_COLOR
 import br.com.concrete.yosef.api.property.id.IdCommand
 import br.com.concrete.yosef.api.property.id.IdCommand.Companion.ID
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.api.property.text.TextColorCommand
@@ -43,6 +45,7 @@ class RadioButtonComponent : Component {
         TEXT_SIZE to TextSizeCommand(),
         TINT_COLOR to TintColorCommand(),
         PADDING to PaddingPropertyCommand(),
+        MARGIN to MarginPropertyCommand(),
         ID to IdCommand()
     )
 

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/RadioGroupButtonComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/RadioGroupButtonComponent.kt
@@ -12,6 +12,8 @@ import br.com.concrete.yosef.api.property.color.BackgroundColorCommand
 import br.com.concrete.yosef.api.property.color.BackgroundColorCommand.Companion.BACKGROUND_COLOR
 import br.com.concrete.yosef.api.property.id.IdCommand
 import br.com.concrete.yosef.api.property.id.IdCommand.Companion.ID
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.entity.DynamicProperty
@@ -32,6 +34,7 @@ class RadioGroupButtonComponent : Component {
     private val commands: Map<String, DynamicPropertyCommand> = mapOf(
         BACKGROUND_COLOR to BackgroundColorCommand(),
         PADDING to PaddingPropertyCommand(),
+        MARGIN to MarginPropertyCommand(),
         ID to IdCommand()
     )
 

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/TextFieldComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/TextFieldComponent.kt
@@ -17,6 +17,8 @@ import br.com.concrete.yosef.api.property.size.HeightCommand
 import br.com.concrete.yosef.api.property.size.HeightCommand.Companion.HEIGHT_TYPE
 import br.com.concrete.yosef.api.property.size.WidthCommand
 import br.com.concrete.yosef.api.property.size.WidthCommand.Companion.WIDTH_TYPE
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.entity.DynamicProperty
@@ -38,6 +40,7 @@ class TextFieldComponent : Component {
         WIDTH_TYPE to WidthCommand(),
         HEIGHT_TYPE to HeightCommand(),
         PADDING to PaddingPropertyCommand(),
+        MARGIN to MarginPropertyCommand(),
         ID to IdCommand()
     )
 

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/component/TextViewComponent.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/component/TextViewComponent.kt
@@ -9,6 +9,8 @@ import br.com.concrete.yosef.OnActionListener
 import br.com.concrete.yosef.api.property.DynamicPropertyCommand
 import br.com.concrete.yosef.api.property.id.IdCommand
 import br.com.concrete.yosef.api.property.id.IdCommand.Companion.ID
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand
+import br.com.concrete.yosef.api.property.spacing.MarginPropertyCommand.Companion.MARGIN
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand
 import br.com.concrete.yosef.api.property.spacing.PaddingPropertyCommand.Companion.PADDING
 import br.com.concrete.yosef.api.property.text.TextColorCommand
@@ -37,6 +39,7 @@ class TextViewComponent : Component {
         TEXT_SIZE to TextSizeCommand(),
         ID to IdCommand(),
         PADDING to PaddingPropertyCommand(),
+        MARGIN to MarginPropertyCommand(),
         TEXT_STYLE to TextStyleCommand()
     )
 

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
@@ -1,0 +1,49 @@
+package br.com.concrete.yosef.api.property.spacing
+
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import br.com.concrete.yosef.api.property.DynamicPropertyCommand
+import br.com.concrete.yosef.dp
+import br.com.concrete.yosef.entity.DynamicProperty
+
+/**
+ * Command class that implements the [DynamicPropertyCommand] applying
+ * padding to a view view
+ *
+ * @see [View.setPadding]
+ */
+class MarginPropertyCommand : DynamicPropertyCommand {
+
+    companion object {
+        /**
+         * Name of the property that can be used in the json
+         */
+        const val MARGIN = "margin"
+    }
+
+    override fun apply(view: View, dynamicProperty: DynamicProperty) {
+        val layoutParams = view.layoutParams
+
+        val (left, top, right, bottom) = generateMarginList(dynamicProperty, view)
+
+        if (layoutParams is LinearLayout.LayoutParams) {
+            layoutParams.setMargins(left, top, right, bottom)
+        } else if (layoutParams is FrameLayout.LayoutParams) {
+            layoutParams.setMargins(left, top, right, bottom)
+        }
+    }
+
+    private fun generateMarginList(dynamicProperty: DynamicProperty, view: View): List<Int> {
+        return if (dynamicProperty.value.contains(",")) {
+            dynamicProperty.value
+                .split(",")
+                .map {
+                    it.trim().toInt().dp(view.context)
+                }
+        } else {
+            val value = dynamicProperty.value.toInt().dp(view.context)
+            listOf(value, value, value, value)
+        }
+    }
+}

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
@@ -42,7 +42,7 @@ class MarginPropertyCommand : DynamicPropertyCommand {
                     it.trim().toInt().dp(view.context)
                 }
         } else {
-            val value = dynamicProperty.value.toInt().dp(view.context)
+            val value = dynamicProperty.value.trim().toInt().dp(view.context)
             listOf(value, value, value, value)
         }
     }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
@@ -39,7 +39,8 @@ class MarginPropertyCommand : DynamicPropertyCommand {
             val split = dynamicProperty.value.split(",")
 
             if (split.size != 4) {
-                throw IllegalArgumentException("The margin value must be a array of 4 items or one number")
+                throw IllegalArgumentException("The margin value must be an array of 4 items or " +
+                    "a single number representing the values of all corners")
             }
 
             split.map {
@@ -56,7 +57,7 @@ class MarginPropertyCommand : DynamicPropertyCommand {
             return valueInString.trim().toInt().dp(context)
         } catch (e: NumberFormatException) {
             throw IllegalArgumentException("The value $valueInString is not a valid margin" +
-                " value, it need to be a number")
+                " value, it needs to be a number")
         }
     }
 }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
@@ -1,5 +1,6 @@
 package br.com.concrete.yosef.api.property.spacing
 
+import android.content.Context
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.LinearLayout
@@ -9,9 +10,9 @@ import br.com.concrete.yosef.entity.DynamicProperty
 
 /**
  * Command class that implements the [DynamicPropertyCommand] applying
- * padding to a view view
+ * margin to a view
  *
- * @see [View.setPadding]
+ * @see [LinearLayout.LayoutParams.setMargins] or [FrameLayout.LayoutParams.setMargins]
  */
 class MarginPropertyCommand : DynamicPropertyCommand {
 
@@ -39,11 +40,20 @@ class MarginPropertyCommand : DynamicPropertyCommand {
             dynamicProperty.value
                 .split(",")
                 .map {
-                    it.trim().toInt().dp(view.context)
+                    convertValueToDp(it, view.context)
                 }
         } else {
-            val value = dynamicProperty.value.trim().toInt().dp(view.context)
-            listOf(value, value, value, value)
+            val value = convertValueToDp(dynamicProperty.value, view.context)
+            MutableList(4) { value }
+        }
+    }
+
+    private fun convertValueToDp(valueInString: String, context: Context): Int {
+        try {
+            return valueInString.trim().toInt().dp(context)
+        } catch (e: NumberFormatException) {
+            throw IllegalArgumentException("The value $valueInString is not a valid margin" +
+                " value, it need to be a number")
         }
     }
 }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/MarginPropertyCommand.kt
@@ -2,6 +2,7 @@ package br.com.concrete.yosef.api.property.spacing
 
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import br.com.concrete.yosef.api.property.DynamicPropertyCommand
@@ -28,20 +29,22 @@ class MarginPropertyCommand : DynamicPropertyCommand {
 
         val (left, top, right, bottom) = generateMarginList(dynamicProperty, view)
 
-        if (layoutParams is LinearLayout.LayoutParams) {
-            layoutParams.setMargins(left, top, right, bottom)
-        } else if (layoutParams is FrameLayout.LayoutParams) {
+        if (layoutParams is ViewGroup.MarginLayoutParams) {
             layoutParams.setMargins(left, top, right, bottom)
         }
     }
 
     private fun generateMarginList(dynamicProperty: DynamicProperty, view: View): List<Int> {
         return if (dynamicProperty.value.contains(",")) {
-            dynamicProperty.value
-                .split(",")
-                .map {
-                    convertValueToDp(it, view.context)
-                }
+            val split = dynamicProperty.value.split(",")
+
+            if (split.size != 4) {
+                throw IllegalArgumentException("The margin value must be a array of 4 items or one number")
+            }
+
+            split.map {
+                convertValueToDp(it, view.context)
+            }
         } else {
             val value = convertValueToDp(dynamicProperty.value, view.context)
             MutableList(4) { value }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
@@ -22,10 +22,21 @@ class PaddingPropertyCommand : DynamicPropertyCommand {
 
     override fun apply(view: View, dynamicProperty: DynamicProperty) {
 
-        val (left, top, right, bottom) = dynamicProperty.value
-            .split(',')
-            .map { it.toInt().dp(view.context) }
+        val (left, top, right, bottom) = generateMarginList(dynamicProperty, view)
 
         view.setPadding(left, top, right, bottom)
+    }
+
+    private fun generateMarginList(dynamicProperty: DynamicProperty, view: View): List<Int> {
+        return if (dynamicProperty.value.contains(",")) {
+            dynamicProperty.value
+                .split(",")
+                .map {
+                    it.trim().toInt().dp(view.context)
+                }
+        } else {
+            val value = dynamicProperty.value.trim().toInt().dp(view.context)
+            listOf(value, value, value, value)
+        }
     }
 }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
@@ -33,7 +33,8 @@ class PaddingPropertyCommand : DynamicPropertyCommand {
             val split = dynamicProperty.value.split(",")
 
             if (split.size != 4) {
-                throw IllegalArgumentException("The padding value must be a array of 4 items or one number")
+                throw IllegalArgumentException("The padding value must be an array of 4 items or " +
+                    "a single number representing the values of all corners")
             }
 
             split.map {
@@ -50,7 +51,7 @@ class PaddingPropertyCommand : DynamicPropertyCommand {
             return valueInString.trim().toInt().dp(context)
         } catch (e: NumberFormatException) {
             throw IllegalArgumentException("The value $valueInString is not a valid padding" +
-                " value, it need to be a number")
+                " value, it needs to be a number")
         }
     }
 }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
@@ -1,5 +1,6 @@
 package br.com.concrete.yosef.api.property.spacing
 
+import android.content.Context
 import android.view.View
 import br.com.concrete.yosef.api.property.DynamicPropertyCommand
 import br.com.concrete.yosef.dp
@@ -29,14 +30,27 @@ class PaddingPropertyCommand : DynamicPropertyCommand {
 
     private fun generatePaddingList(dynamicProperty: DynamicProperty, view: View): List<Int> {
         return if (dynamicProperty.value.contains(",")) {
-            dynamicProperty.value
-                .split(",")
-                .map {
-                    it.trim().toInt().dp(view.context)
-                }
+            val split = dynamicProperty.value.split(",")
+
+            if (split.size != 4) {
+                throw IllegalArgumentException("The padding value must be a array of 4 items or one number")
+            }
+
+            split.map {
+                convertValueToDp(it, view.context)
+            }
         } else {
-            val value = dynamicProperty.value.trim().toInt().dp(view.context)
+            val value = convertValueToDp(dynamicProperty.value, view.context)
             MutableList(4) { value }
+        }
+    }
+
+    private fun convertValueToDp(valueInString: String, context: Context): Int {
+        try {
+            return valueInString.trim().toInt().dp(context)
+        } catch (e: NumberFormatException) {
+            throw IllegalArgumentException("The value $valueInString is not a valid padding" +
+                " value, it need to be a number")
         }
     }
 }

--- a/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
+++ b/core/src/main/kotlin/br/com/concrete/yosef/api/property/spacing/PaddingPropertyCommand.kt
@@ -22,12 +22,12 @@ class PaddingPropertyCommand : DynamicPropertyCommand {
 
     override fun apply(view: View, dynamicProperty: DynamicProperty) {
 
-        val (left, top, right, bottom) = generateMarginList(dynamicProperty, view)
+        val (left, top, right, bottom) = generatePaddingList(dynamicProperty, view)
 
         view.setPadding(left, top, right, bottom)
     }
 
-    private fun generateMarginList(dynamicProperty: DynamicProperty, view: View): List<Int> {
+    private fun generatePaddingList(dynamicProperty: DynamicProperty, view: View): List<Int> {
         return if (dynamicProperty.value.contains(",")) {
             dynamicProperty.value
                 .split(",")
@@ -36,7 +36,7 @@ class PaddingPropertyCommand : DynamicPropertyCommand {
                 }
         } else {
             val value = dynamicProperty.value.trim().toInt().dp(view.context)
-            listOf(value, value, value, value)
+            MutableList(4) { value }
         }
     }
 }


### PR DESCRIPTION
Create a margin command property that accepts one or multiple values i.e.:

```
"name": "margin",
"type": "dimen",
"value": "16"
```
This will apply this margin to all sides of the view, or:

```
"name": "margin",
"type": "dimen",
"value": "16, 0, 16, 0"
```

This will apply the margins left, top, right and bottom following the android's api original order.

I've applied this same logic to the padding property.